### PR TITLE
Fix identification of the tracking

### DIFF
--- a/lib/delivery/client/delivery_query.rb
+++ b/lib/delivery/client/delivery_query.rb
@@ -300,7 +300,7 @@ module Kontent
         end
 
         def provide_sdk_header
-          'rubygems.org;delivery-sdk-ruby;'
+          'rubygems.org;kontent-ai-delivery;'
         end
       end
     end


### PR DESCRIPTION
### Motivation

The ID of the app is "kontent-ai-delivery" - https://rubygems.org/gems/kontent-ai-delivery so the identification should respect that. The name of the repo can be different.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
